### PR TITLE
add "::1" to default InternalHosts list

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -1577,11 +1577,11 @@ arcf_config_load(struct config *data, struct arcf_config *conf,
 		(void) config_get(data, "InternalHosts", &str, sizeof str);
 	if (str != NULL)
 	{
-		int status;
+		_Bool status;
 		char *dberr = NULL;
 
 		status = arcf_list_load(&conf->conf_internal, str, &dberr);
-		if (status != 0)
+		if (!status)
 		{
 			snprintf(err, errlen, "%s: arcf_list_load(): %s",
 			         str, dberr);
@@ -1593,8 +1593,17 @@ arcf_config_load(struct config *data, struct arcf_config *conf,
 		_Bool status;
 		char *dberr = NULL;
 
-		status = arcf_addlist(&conf->conf_internal, "127.0.0.1",
-		                      &dberr);
+		str = LOCALHOST;
+		status = arcf_addlist(&conf->conf_internal, str, &dberr);
+		if (!status)
+		{
+			snprintf(err, errlen, "%s: arcf_addlist(): %s",
+			         str, dberr);
+			return -1;
+		}
+
+		str = LOCALHOST6;
+		status = arcf_addlist(&conf->conf_internal, str, &dberr);
 		if (!status)
 		{
 			snprintf(err, errlen, "%s: arcf_addlist(): %s",

--- a/openarc/openarc.h
+++ b/openarc/openarc.h
@@ -45,6 +45,7 @@
 #define	HOSTUNKNOWN	"unknown-host"
 #define	JOBIDUNKNOWN	"(unknown-jobid)"
 #define	LOCALHOST	"127.0.0.1"
+#define	LOCALHOST6	"::1"
 #define	MAXADDRESS	256
 #define	MAXARGV		65536
 #define	MAXBUFRSZ	65536


### PR DESCRIPTION
Add "::1" to default InternalHosts list as most systems prefer IPv6 over IPv4 and fix the declaration and test of the variable holding the return value of arcf_list_load().