### PR TITLE
Fix semicolon termination of results in ARC-Authentication-Results

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3565,10 +3565,20 @@ mlfi_eom(SMFICTX *ctx)
 						                    ar.ares_result[0].result_reason);
 					}
 
-					if (n != ar.ares_count - 1)
+					/* append semicolon unless this is the last result in this AR header */
+					if (n < ar.ares_count - 1)
+					{
 						arcf_dstring_cat(afc->mctx_tmpstr, "; ");
+					}
 				}
 			}
+
+			/* append semicolon unless this is the last AR header */
+			if (arcf_findheader(afc, AR_HEADER_NAME, c + 1) != NULL)
+			{
+				arcf_dstring_cat(afc->mctx_tmpstr, "; ");
+			}
+
 		}
 
 		/*


### PR DESCRIPTION
Ensure results are always terminated correctly in the ARC-Authentication-Results header when multiple Authentication-Results headers are present.

This fixes issue #47.