### PR TITLE
possible solution for issue #72

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -1281,7 +1281,7 @@ arcf_addlist(struct conflist *list, char *str, char **err)
 		*err = strerror(errno);
 		return FALSE;
 	}
-	v->value = str;
+	v->value = strdup(str);
 
 	LIST_INSERT_HEAD(list, v, entries);
 	return TRUE;


### PR DESCRIPTION
arcf_list_load() use strdup() to popolate values into the LIST
(openarc/openarc.c, line 1245) but arcf_addlist() don't.

adding strdup() make a later free (openarc/openarc.c, line 1309) don't crash
#72 solved?