### PR TITLE
Final receiver functionality for communicating chain sealers downstream to a policy engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ stamp-h1
 *~
 *.cache
 *#*
+.vscode
 
 # compilation artifacts
 libopenarc/symbols.map

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,5 +3,10 @@
 This listing shows the versions of the OpenARC package, the date of
 release, and a summary of the changes in that release.
 
+0.1.1		2017/12/11
+	Fix issue #47: Fix syntax of ARC-Authentication-Results with respect
+		to semicolons.  Problem noted by Matt Domsch; based on a
+		patch from Ben Arblaster.
+
 0.1.0		2017/12/06
 	Initial pre-release.

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,11 +3,9 @@
 This listing shows the versions of the OpenARC package, the date of
 release, and a summary of the changes in that release.
 
-0.1.X		2018/??/??
+0.1.1		2018/??/??
 	Add FinalReceiver configuration option. When enabled, this filter will
-		append "arc.chain=dom(n)...dom(1)" custody chain data to the A-R field. 
-
-0.1.1		2017/12/11
+		append "arc.chain=dom(n)...dom(1)" custody chain data to the A-R field.
 	Fix issue #47: Fix syntax of ARC-Authentication-Results with respect
 		to semicolons.  Problem noted by Matt Domsch; based on a
 		patch from Ben Arblaster.

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,6 +3,10 @@
 This listing shows the versions of the OpenARC package, the date of
 release, and a summary of the changes in that release.
 
+0.1.X		2018/??/??
+	Add FinalReceiver configuration option. When enabled, this filter will
+		append "arc.chain=dom(n)...dom(1)" custody chain data to the A-R field. 
+
 0.1.1		2017/12/11
 	Fix issue #47: Fix syntax of ARC-Authentication-Results with respect
 		to semicolons.  Problem noted by Matt Domsch; based on a

--- a/libopenarc/arc.h
+++ b/libopenarc/arc.h
@@ -574,7 +574,8 @@ extern const char *arc_chain_status_str __P((ARC_MESSAGE *msg));
 **      buflen -- bytes at "buf"
 **
 **	Return value:
-**	    Number of bytes written
+**	    Number of bytes written. If value is greater than or equal to buflen
+**		argument, then buffer was too small and output was truncated.
 */
 extern int arc_chain_custody_str __P((ARC_MESSAGE *msg, u_char *buf, size_t buflen));
 

--- a/libopenarc/arc.h
+++ b/libopenarc/arc.h
@@ -554,7 +554,7 @@ extern uint64_t arc_ssl_version __P((void));
 extern char *arc_get_domain __P((ARC_MESSAGE *msg));
 
 /*
-**  ARC_CHAIN_STR -- retrieve chain status, as a string
+**  ARC_CHAIN_STATUS_STR -- retrieve chain status, as a string
 **
 **  Parameters:
 **      msg -- ARC_MESSAGE object
@@ -563,7 +563,20 @@ extern char *arc_get_domain __P((ARC_MESSAGE *msg));
 **      Pointer to string containing the current chain status.
 */
 
-extern const char *arc_chain_str __P((ARC_MESSAGE *msg));
+extern const char *arc_chain_status_str __P((ARC_MESSAGE *msg));
+
+/*
+**	ARC_CHAIN_CUSTODY_STR -- retrieve domain chain, as a string
+**
+**	Parameters:
+**      msg -- ARC_MESSAGE object
+**      buf -- where to write
+**      buflen -- bytes at "buf"
+**
+**	Return value:
+**	    Number of bytes written
+*/
+extern int arc_chain_custody_str __P((ARC_MESSAGE *msg, u_char *buf, size_t buflen));
 
 #ifdef __cplusplus
 }

--- a/openarc/openarc-config.h
+++ b/openarc/openarc-config.h
@@ -31,6 +31,7 @@ struct configdef arcf_config[] =
 	{ "ChangeRootDirectory",	CONFIG_TYPE_STRING,	FALSE },
 	{ "Domain",			CONFIG_TYPE_STRING,	TRUE },
 	{ "EnableCoredumps",		CONFIG_TYPE_BOOLEAN,	FALSE },
+	{ "FinalReceiver",		CONFIG_TYPE_BOOLEAN, FALSE },
 	{ "FixedTimestamp",		CONFIG_TYPE_STRING,	FALSE },
 	{ "Include",			CONFIG_TYPE_INCLUDE,	FALSE },
 	{ "InternalHosts",		CONFIG_TYPE_STRING,	FALSE },

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3533,6 +3533,14 @@ mlfi_eom(SMFICTX *ctx)
 
 						arc_set_cv(afc->mctx_arcmsg,
 						           cv);
+
+						continue;
+					}
+
+					if (arcf_dstring_len(afc->mctx_tmpstr) > 0)
+					{
+						arcf_dstring_cat(afc->mctx_tmpstr,
+						                 "; ");
 					}
 
 					arcf_dstring_printf(afc->mctx_tmpstr,

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -116,6 +116,7 @@ struct arcf_config
 	_Bool		conf_addswhdr;		/* add software header field */
 	_Bool		conf_safekeys;		/* require safe keys */
 	_Bool		conf_keeptmpfiles;	/* keep temp files */
+	_Bool		conf_finalreceiver; /* act as final receiver */
 	u_int		conf_refcnt;		/* reference count */
 	u_int		conf_mode;		/* mode flags */
 	arc_canon_t	conf_canonhdr;		/* canonicalization for header */
@@ -1480,6 +1481,10 @@ arcf_config_load(struct config *data, struct arcf_config *conf,
 		(void) config_get(data, "EnableCoredumps",
 		                  &conf->conf_enablecores,
 		                  sizeof conf->conf_enablecores);
+
+		(void) config_get(data, "FinalReceiver",
+		                  &conf->conf_finalreceiver,
+						  sizeof conf->conf_finalreceiver);
 
 		(void) config_get(data, "TemporaryDirectory",
 		                  &conf->conf_tmpdir,

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -89,7 +89,6 @@
 
 /* macros */
 #define CMDLINEOPTS	"Ac:fhlnp:P:r:t:u:vV"
-#define AR_HEADER_NAME	"Authentication-Results"
 
 /*
 **  CONFIGVALUE -- a list of configuration values
@@ -3457,7 +3456,7 @@ mlfi_eom(SMFICTX *ctx)
 		/* assemble authentication results */
 		for (c = 0; ; c++)
 		{
-			hdr = arcf_findheader(afc, AR_HEADER_NAME, c);
+			hdr = arcf_findheader(afc, AUTHRESULTSHDR, c);
 			if (hdr == NULL)
 				break;
 			status = ares_parse(hdr->hdr_val, &ar);
@@ -3467,7 +3466,7 @@ mlfi_eom(SMFICTX *ctx)
 				{
 					syslog(LOG_WARNING,
 					       "%s: can't parse %s; ignoring",
-					       afc->mctx_jobid, AR_HEADER_NAME);
+					       afc->mctx_jobid, AUTHRESULTSHDR);
 				}
 
 				continue;

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3589,7 +3589,7 @@ mlfi_eom(SMFICTX *ctx)
 			if (arcf_dstring_len(afc->mctx_tmpstr) > 0)
 				arcf_dstring_cat(afc->mctx_tmpstr, "; ");
 			arcf_dstring_printf(afc->mctx_tmpstr, "arc=%s",
-			                    arc_chain_str(afc->mctx_arcmsg));
+			                    arc_chain_status_str(afc->mctx_arcmsg));
 		}
 
 		/*
@@ -3650,13 +3650,19 @@ mlfi_eom(SMFICTX *ctx)
 		/*
  		**  Authentication-Results
 		*/
+		u_char arcchainbuf[ARC_MAXHEADER + 1];
+		int arcchainlen = arc_chain_custody_str(afc->mctx_arcmsg, arcchainbuf, sizeof(arcchainbuf));
 
 		arcf_dstring_blank(afc->mctx_tmpstr);
 		arcf_dstring_printf(afc->mctx_tmpstr,
 		                    "%s%s; arc=%s",
 		                    cc->cctx_noleadspc ? " " : "",
 		                    conf->conf_authservid,
-		                    arc_chain_str(afc->mctx_arcmsg));
+		                    arc_chain_status_str(afc->mctx_arcmsg));
+		if (conf->conf_finalreceiver && arcchainlen > 0)
+		{
+			arcf_dstring_printf(afc->mctx_tmpstr, " arc.chain=%s", arcchainbuf);
+		}
 		if (arcf_insheader(ctx, 1, AUTHRESULTSHDR,
 		                   arcf_dstring_get(afc->mctx_tmpstr)) != MI_SUCCESS)
 		{

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -115,7 +115,7 @@ struct arcf_config
 	_Bool		conf_addswhdr;		/* add software header field */
 	_Bool		conf_safekeys;		/* require safe keys */
 	_Bool		conf_keeptmpfiles;	/* keep temp files */
-	_Bool		conf_finalreceiver; /* act as final receiver */
+	_Bool		conf_finalreceiver;	/* act as final receiver */
 	u_int		conf_refcnt;		/* reference count */
 	u_int		conf_mode;		/* mode flags */
 	arc_canon_t	conf_canonhdr;		/* canonicalization for header */
@@ -3651,7 +3651,21 @@ mlfi_eom(SMFICTX *ctx)
  		**  Authentication-Results
 		*/
 		u_char arcchainbuf[ARC_MAXHEADER + 1];
-		int arcchainlen = arc_chain_custody_str(afc->mctx_arcmsg, arcchainbuf, sizeof(arcchainbuf));
+		int arcchainlen = arc_chain_custody_str(afc->mctx_arcmsg,
+		                                        arcchainbuf,
+		                                        sizeof(arcchainbuf));
+
+		if (arcchainlen >= ARC_MAXHEADER + 1)
+		{
+			if (conf->conf_dolog)
+			{
+				syslog(LOG_ERR,
+				       "%s: arc.chain buffer overflow: %s",
+				       afc->mctx_jobid, "");
+			}
+
+			return SMFIS_TEMPFAIL;
+		}
 
 		arcf_dstring_blank(afc->mctx_tmpstr);
 		arcf_dstring_printf(afc->mctx_tmpstr,

--- a/openarc/openarc.conf.sample
+++ b/openarc/openarc.conf.sample
@@ -123,6 +123,14 @@ Domain			example.com
 
 KeyFile			/var/db/dkim/example.private
 
+## FinalReceiver { yes | no }
+##      default "no"
+##
+## If set, causes this filter to pass chain signatory information downstream for
+## local policy evaluation in the event of an authentication failure.
+
+FinalReceiver { yes | no }
+
 ##  MaximumHeaders n
 ##
 ##  Disallow messages whose header blocks are bigger than "n" bytes.


### PR DESCRIPTION
Adds `FinalReceiver` configuration option that when enabled causes OpenARC to output the arc custody chain in the A-R header:

```text
Authentication-Results: arctest.net; arc=pass arc.chain=bungie.com:google.com
```
