### PR TITLE
Added ability to use custom resolver

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -1015,7 +1015,6 @@ arc_options(ARC_LIB *lib, int op, int arg, void *val, size_t valsz)
 	}
 }
 
-
 /*
 **
 **  ARC_INIT_DNS -- override and initialize library DNS resolver

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -1015,6 +1015,61 @@ arc_options(ARC_LIB *lib, int op, int arg, void *val, size_t valsz)
 	}
 }
 
+
+/*
+**
+**  ARC_INIT_DNS -- override and initialize library DNS resolver
+**
+**  Parameters:
+**  	lib			-- library to set DNS for
+**	srv			-- resolver handle to use
+**	arc_dns_close		-- terminates a resolver
+**	arc_dns_start		-- starts a DNS query
+**  	arc_dns_cancel		-- cancels a DNS query
+**  	arc_dns_waitreply	-- synchronously waits on a DNS response
+**
+**  Return value:
+**  	An ARC_STAT_* constant.
+*/
+
+ARC_STAT
+arc_init_dns(ARC_LIB *lib, void* srv,
+	     void (*arc_dns_close) (void *srv),
+	     int (*arc_dns_start) (void *srv, int type,
+				   unsigned char *query,
+				   unsigned char *buf,
+				   size_t buflen,
+				   void **qh),
+	     int (*arc_dns_cancel) (void *srv, void *qh),
+	     int (*arc_dns_waitreply) (void *srv,
+				       void *qh,
+				       struct timeval *to,
+				       size_t *bytes,
+				       int *error,
+				       int *dnssec))
+{
+	assert(lib != NULL);
+	assert(srv != 0);
+	assert(arc_dns_close != 0);
+	assert(arc_dns_start != 0);
+	assert(arc_dns_cancel != 0);
+	assert(arc_dns_waitreply != 0);
+
+	/* "illegal state" would be better */
+	if (lib->arcl_dnsinit_done)
+		return ARC_STAT_INTERNAL;
+
+	lib->arcl_dnsinit_done = TRUE;
+	lib->arcl_dns_service = srv;
+	lib->arcl_dns_init = 0;
+	lib->arcl_dns_close = arc_dns_close;
+	lib->arcl_dns_start = arc_dns_start;
+	lib->arcl_dns_cancel = arc_dns_cancel;
+	lib->arcl_dns_waitreply = arc_dns_waitreply;
+
+	return ARC_STAT_OK;
+}
+
 /*
 **  ARC_GETSSLBUF -- retrieve SSL error buffer
 **

--- a/libopenarc/arc.h
+++ b/libopenarc/arc.h
@@ -361,6 +361,37 @@ extern const char *arc_geterror __P((ARC_MESSAGE *));
 extern ARC_STAT arc_options __P((ARC_LIB *, int, int, void *, size_t));
 
 /*
+**
+**  ARC_INIT_DNS -- override and initialize library DNS resolver
+**
+**  Parameters:
+**  	lib			-- library to set DNS for
+**	srv			-- resolver handle to use
+**	arc_dns_close		-- terminates a resolver
+**	arc_dns_start		-- starts a DNS query
+**  	arc_dns_cancel		-- cancels a DNS query
+**  	arc_dns_waitreply	-- synchronously waits on a DNS response
+**
+**  Return value:
+**  	An ARC_STAT_* constant.
+*/
+
+extern ARC_STAT arc_init_dns __P((ARC_LIB *, void* srv,
+				  void (*arc_dns_close) (void *srv),
+				  int (*arc_dns_start) (void *srv, int type,
+							unsigned char *query,
+							unsigned char *buf,
+							size_t buflen,
+							void **qh),
+				 int (*arc_dns_cancel) (void *srv, void *qh),
+				 int (*arc_dns_waitreply) (void *srv,
+							   void *qh,
+							   struct timeval *to,
+							   size_t *bytes,
+							   int *error,
+							   int *dnssec)));
+
+/*
 **  ARC_GETSSLBUF -- retrieve SSL error buffer
 **
 **  Parameters:


### PR DESCRIPTION
Hi Murray, I used this to override the internal use of libresolv and such to
connect to PowerMTA's internal resolver, as well as to be able to provide
test DNS responses.

Since we're really only initializing the resolver library, whatever it may be,
once per ARC_LIB, I opted for a simple approach where I passed in the
library handle.

Alternatively, we could instead pass in an ``arc_dns_init`` function pointer,
but in this case I'd need to be able to pass in a "user data" pointer, as in
```
extern ARC_STAT arc_init_dns __P((ARC_LIB *, void* srv,
				  void *user,
				  void (*arc_dns_init) (void *user),
				  void (*arc_dns_close) (void *srv),
				  int (*arc_dns_start) (void *srv, int type,
							unsigned char *query,
							unsigned char *buf,
							size_t buflen,
							void **qh),
				 int (*arc_dns_cancel) (void *srv, void *qh),
				 int (*arc_dns_waitreply) (void *srv,
							   void *qh,
							   struct timeval *to,
							   size_t *bytes,
							   int *error,
							   int *dnssec)));
```