### PR TITLE
Fix mail sent from localhost generates wrong AAR stamp

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -3204,7 +3204,7 @@ arc_getseal(ARC_MESSAGE *msg, ARC_HDRFIELD **seal, char *authservid,
 	**  Part 1: Construct a new AAR
 	*/
 
-	arc_dstring_printf(dstr, "ARC-Authentication-Results: i=%u; %s; %s",
+	arc_dstring_printf(dstr, "ARC-Authentication-Results: i=%u; %s; arc=%s",
 	                   msg->arc_nsets + 1,
 	                   msg->arc_authservid,
 	                   ar == NULL ? "none" : (char *) ar);


### PR DESCRIPTION
When a message is constructed locally (for local or external delivery), the following happens:
- No arc Authentication-Results stamp is added to the message
- The AAR looks like this: `ARC-Authentication-Results: i=1; lists.arctest.net; none`
   Expected: AAR: `i=1; lists.arctest.net; arc=none smtp.client-ip=127.0.0.1`