### PR TITLE
Patch for issue #100 by A.Schulze

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3673,11 +3673,11 @@ mlfi_eom(SMFICTX *ctx)
 			hfptr = arc_hdr_name(sealhdr, &len);
 			hfdest = hfname;
 			memset(hfname, '\0', sizeof hfname);
-			if (cc->cctx_noleadspc)
+/*			if (cc->cctx_noleadspc)
 			{
 				hfname[0] = ' ';
 				hfdest++;
-			}
+			} */
 			strncpy(hfdest, hfptr, len);
 
 			status = arcf_insheader(ctx, 1, hfname,


### PR DESCRIPTION
Description: no leading spaces for ARC- headers
URL: https://github.com/trusteddomainproject/OpenARC/issues/100
Author: A.Schulze
---
This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
Downloaded from https://build.opensuse.org/package/show/home:andreasschulze/openarc in archive openarc_1.0.0~beta0-2.debian.tar.xz