### PR TITLE
fix typo, 'openarc -c config' instead of 'openarc -x config'

### DIFF
--- a/contrib/init/redhat/openarc.in
+++ b/contrib/init/redhat/openarc.in
@@ -43,7 +43,7 @@ start() {
 		echo OpenARC already running as pid $PID
 	        exit 2;
 	else
-		daemon $DAEMON -x $CONF_FILE -P $PID_FILE
+		daemon $DAEMON -c $CONF_FILE -P $PID_FILE
 		RETVAL=$?
 		[ $RETVAL -eq 0 ] && touch /var/lock/subsys/openarc
 		echo

--- a/contrib/init/solaris/openarc
+++ b/contrib/init/solaris/openarc
@@ -8,7 +8,7 @@ PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin; export PATH
 . /lib/svc/share/smf_include.sh
 
 echo "starting openarc"
-openarc -x /etc/mail/openarc.conf
+openarc -c /etc/mail/openarc.conf
 echo "started openarc"
 exit $SMF_EXIT_OK
 


### PR DESCRIPTION
Fix argument to point openarc to it's configuration file.