### PR TITLE
Fixed Redhat daemon config option.

### DIFF
--- a/contrib/init/redhat/openarc.in
+++ b/contrib/init/redhat/openarc.in
@@ -43,7 +43,7 @@ start() {
 		echo OpenARC already running as pid $PID
 	        exit 2;
 	else
-		daemon $DAEMON -x $CONF_FILE -P $PID_FILE
+		daemon $DAEMON -c $CONF_FILE -P $PID_FILE
 		RETVAL=$?
 		[ $RETVAL -eq 0 ] && touch /var/lock/subsys/openarc
 		echo


### PR DESCRIPTION
Openarc binary does not support '-x' option to specify the configuration file, the correct option is '-c'.